### PR TITLE
feat(logging): integrate Serilog with Seq support

### DIFF
--- a/HoneyHub.Platform/Apps/Admin/HoneyHub.Admin/HoneyHub.Admin.csproj
+++ b/HoneyHub.Platform/Apps/Admin/HoneyHub.Admin/HoneyHub.Admin.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Shared\HoneyHub.Logging\HoneyHub.Logging.csproj" />
     <ProjectReference Include="..\..\..\Shared\HoneyHub.Platform.ServiceDefaults\HoneyHub.Platform.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/HoneyHub.Platform/HoneyHub.Users.Api/HoneyHub.Users.Api.csproj
+++ b/HoneyHub.Platform/HoneyHub.Users.Api/HoneyHub.Users.Api.csproj
@@ -13,11 +13,13 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageReference Include="HoneyHub.Users.Api.Sdk" Version="1.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.8.3" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.8.4" />
     <PackageReference Include="Sentry.AspNetCore" Version="5.15.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Shared\HoneyHub.Logging\HoneyHub.Logging.csproj" />
     <ProjectReference Include="..\Shared\HoneyHub.Outbox\HoneyHub.Outbox.csproj" />
     <ProjectReference Include="..\Shared\HoneyHub.Platform.ServiceDefaults\HoneyHub.Platform.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Domains\Users\HoneyHub.Users.AppService\HoneyHub.Users.AppService.csproj" />

--- a/HoneyHub.Platform/HoneyHub.Users.Api/Program.cs
+++ b/HoneyHub.Platform/HoneyHub.Users.Api/Program.cs
@@ -1,6 +1,7 @@
 using Azure.Core;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
+using HoneyHub.Logging;
 using HoneyHub.Platform.ServiceDefaults;
 using HoneyHub.Users.Api.Endpoints;
 using HoneyHub.Users.Api.Extensions;
@@ -9,6 +10,12 @@ using HoneyHub.Users.DataService.Context;
 using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.AddHoneyHubSerilog(cfg =>
+{
+    // optional per-app tuning; safe to leave empty
+    // cfg.MinimumLevel.Override("Microsoft.AspNetCore", Serilog.Events.LogEventLevel.Warning);
+});
 
 var kvName = builder.Configuration["KeyVault:Name"];
 var orgPrefix = builder.Configuration["KeyVault:OrgPrefix"] ?? "Org";

--- a/HoneyHub.Platform/HoneyHub.Users.Api/appsettings.json
+++ b/HoneyHub.Platform/HoneyHub.Users.Api/appsettings.json
@@ -1,17 +1,25 @@
 {
-  "KeyVault": {
-    "Name": "honeyhub-dev-keyvault",
-    "OrgPrefix": "Org",
-    "Service": "UsersApi"
-  },
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
+    },
+    "Enrich": [ "FromLogContext" ],
+    "Properties": {
+      "Application": "HoneyHub.Users.Api"
     }
   },
   "ConnectionStrings": {
     "DefaultConnection": ""
+  },
+  "KeyVault": {
+    "Name": "honeyhub-dev-keyvault",
+    "OrgPrefix": "Org",
+    "Service": "UsersApi"
   },
   "Sentry": {
     "Dsn": "",

--- a/HoneyHub.Platform/Shared/HoneyHub.Logging/HoneyHub.Logging.csproj
+++ b/HoneyHub.Platform/Shared/HoneyHub.Logging/HoneyHub.Logging.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/Program.cs
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/Program.cs
@@ -1,16 +1,47 @@
-using Aspire.Hosting;
+using Microsoft.Extensions.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-// keep the SA password out of source (set via user-secrets on AppHost project)
+// Params (local secrets OK for Local only)
 var saPassword = builder.AddParameter("SqlSaPassword", secret: true);
+var seqAdminPassword = builder.AddParameter("SeqAdminPassword", secret: true);
 
-// Users API points to your existing local SQL (Docker Desktop) on localhost:1433
-builder.AddProject<Projects.HoneyHub_Users_Api>("usersapi")
-    .WithEnvironment(
+// Seq only for Local
+IResourceBuilder<ContainerResource>? seq = null;
+if (builder.Environment.IsDevelopment()) // Local AppHost
+{
+    seq = builder.AddContainer("seq", "datalust/seq:latest")
+        .WithEnvironment("ACCEPT_EULA", "Y")
+        .WithEnvironment("SEQ_FIRSTRUN_ADMINPASSWORD", seqAdminPassword)
+        .WithHttpEndpoint(name: "ui", port: 5341, targetPort: 80)
+        .WithVolume("seq-data", "/data");
+}
+
+IResourceBuilder<ProjectResource> WireApp(IResourceBuilder<ProjectResource> app)
+{
+    // Tell the app which tier it's in (Local/Dev/Prod). Local when AppHost runs.
+    app.WithEnvironment("HONEYHUB_ENV", builder.Environment.IsDevelopment() ? "Local" : "Dev");
+
+    // Common stuff (DB etc.)
+    app.WithEnvironment(
         "ConnectionStrings__DefaultConnection",
         $"Server=localhost,1433;Database=HoneyHub.Users.Database;User ID=sa;Password={saPassword};Encrypt=True;TrustServerCertificate=True;MultipleActiveResultSets=True");
 
-builder.AddProject<Projects.HoneyHub_Admin>("honeyhub-admin");
+    // Serilog base config (console as 0)
+    app.WithEnvironment("Serilog__WriteTo__0__Name", "Console")
+       .WithEnvironment("Serilog__WriteTo__0__Args__formatter", "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact");
+
+    // When Local, add Seq sink
+    if (seq is not null)
+    {
+        app.WithEnvironment("Serilog__WriteTo__1__Name", "Seq")
+           .WithEnvironment("Serilog__WriteTo__1__Args__serverUrl", seq.GetEndpoint("ui"));
+    }
+
+    return app;
+}
+
+WireApp(builder.AddProject<Projects.HoneyHub_Users_Api>("usersapi"));
+WireApp(builder.AddProject<Projects.HoneyHub_Admin>("honeyhub-admin"));
 
 builder.Build().Run();


### PR DESCRIPTION
Added Serilog for structured logging across HoneyHub projects. Integrated `Serilog.Sinks.Seq` for centralized log management via Seq. Updated `HoneyHub.Admin.csproj` and
`HoneyHub.Users.Api.csproj` to include the Seq sink and added a project reference to `HoneyHub.Logging`.

Enhanced `LoggingSetup.cs` with a new `AddHoneyHubSerilog` method, introducing enrichers like `WithSpan` and properties such as `EnvTier` and `AppVersion`. Updated `appsettings.json` to configure Serilog settings, replacing the previous logging configuration.

Refactored `Program.cs` to support Seq logging in local development, including a Seq container setup and environment variable configuration. Introduced a `WireApp` method for shared application settings. Added environment-specific configuration for `HONEYHUB_ENV` to distinguish between `Local` and `Dev` environments.

BREAKING CHANGE: Replaced the `Logging` section in `appsettings.json` with a `Serilog` configuration section. Applications relying on the old logging configuration will need to update their settings.