### PR TITLE
feat(api): add OpenTelemetry for observability

### DIFF
--- a/HoneyHub.Platform/HoneyHub.Users.Api/HoneyHub.Users.Api.csproj
+++ b/HoneyHub.Platform/HoneyHub.Users.Api/HoneyHub.Users.Api.csproj
@@ -13,6 +13,12 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageReference Include="HoneyHub.Users.Api.Sdk" Version="1.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.2" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.8.4" />
     <PackageReference Include="Sentry.AspNetCore" Version="5.15.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/HoneyHub.Platform.AppHost.csproj
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/HoneyHub.Platform.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
 

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/Program.cs
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/Program.cs
@@ -2,46 +2,114 @@ using Microsoft.Extensions.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-// Params (local secrets OK for Local only)
+// ---------- Parameters ----------
 var saPassword = builder.AddParameter("SqlSaPassword", secret: true);
 var seqAdminPassword = builder.AddParameter("SeqAdminPassword", secret: true);
+var grafanaAdminPassword = builder.AddParameter("GrafanaAdminPassword", secret: true);
 
-// Seq only for Local
+// ---------- Local-only containers ----------
 IResourceBuilder<ContainerResource>? seq = null;
-if (builder.Environment.IsDevelopment()) // Local AppHost
+IResourceBuilder<ContainerResource>? otel = null;
+
+if (builder.Environment.IsDevelopment())
 {
+    // Seq (logs UI)
     seq = builder.AddContainer("seq", "datalust/seq:latest")
         .WithEnvironment("ACCEPT_EULA", "Y")
         .WithEnvironment("SEQ_FIRSTRUN_ADMINPASSWORD", seqAdminPassword)
         .WithHttpEndpoint(name: "ui", port: 5341, targetPort: 80)
         .WithVolume("seq-data", "/data");
+
+    // OpenTelemetry Collector
+    // Config at: ./observability/otel-collector.yaml
+    otel = builder.AddContainer("otel-collector", "otel/opentelemetry-collector-contrib:latest")
+        .WithBindMount("./observability/otel-collector.yaml", "/etc/otelcol/config.yaml")
+        .WithArgs("--config=/etc/otelcol/config.yaml")
+        .WithHttpEndpoint(name: "otlpgrpc", port: 4317, targetPort: 4317)   // gRPC
+        .WithHttpEndpoint(name: "otlphttp", port: 4318, targetPort: 4318);  // HTTP
+
+    // Prometheus (scrapes collector’s :8889)
+    // Config at: ./observability/prometheus.yaml
+    builder.AddContainer("prometheus", "prom/prometheus:latest")
+        .WithBindMount("./observability/prometheus.yaml", "/etc/prometheus/prometheus.yml")
+        .WithHttpEndpoint(name: "ui", port: 9090, targetPort: 9090)
+        .WithVolume("prom-data", "/prometheus");
+
+    // Grafana (pre-provision Prometheus datasource)
+    // Config at: ./observability/grafana-datasource.yaml
+    builder.AddContainer("grafana", "grafana/grafana:latest")
+      .WithBindMount("./observability/grafana-datasource.yaml", "/etc/grafana/provisioning/datasources/datasource.yaml")
+      .WithBindMount("./observability/grafana-dashboards.yaml", "/etc/grafana/provisioning/dashboards/dashboards.yaml")
+      .WithBindMount("./observability/dashboards", "/var/lib/grafana/dashboards")
+      .WithEnvironment("GF_SECURITY_ADMIN_USER", "admin")
+      .WithEnvironment("GF_SECURITY_ADMIN_PASSWORD", grafanaAdminPassword)
+      .WithHttpEndpoint(name: "ui", port: 3000, targetPort: 3000)
+      .WithVolume("grafana-data", "/var/lib/grafana");
+
+
+    // --- Tempo (stores traces locally; Grafana reads on :3200)
+    //     Config at: ./observability/tempo.yaml
+    builder.AddContainer("tempo", "grafana/tempo:latest")
+        .WithBindMount("./observability/tempo.yaml", "/etc/tempo.yaml")
+        .WithArgs("-config.file=/etc/tempo.yaml")
+        .WithHttpEndpoint(name: "ui", port: 3200, targetPort: 3200)
+        // Optional persistent storage
+        .WithVolume("tempo-data", "/var/tempo");
+
+    // --- Loki (stores logs locally; Grafana reads on :3100)
+    //     Config at: ./observability/loki.yaml
+    builder.AddContainer("loki", "grafana/loki:latest")
+        .WithBindMount("./observability/loki.yaml", "/etc/loki/config.yaml")
+        .WithArgs("-config.file=/etc/loki/config.yaml")
+        .WithHttpEndpoint(name: "http", port: 3100, targetPort: 3100)
+        .WithVolume("loki-data", "/loki");
 }
 
+// ---------- Helper to stamp common env + OTEL for each app ----------
 IResourceBuilder<ProjectResource> WireApp(IResourceBuilder<ProjectResource> app)
 {
-    // Tell the app which tier it's in (Local/Dev/Prod). Local when AppHost runs.
-    app.WithEnvironment("HONEYHUB_ENV", builder.Environment.IsDevelopment() ? "Local" : "Dev");
+    var env = builder.Environment.IsDevelopment() ? "Local" : "Dev";
 
-    // Common stuff (DB etc.)
+    // Tier flag (Local/Dev/Prod)
+    app.WithEnvironment("HONEYHUB_ENV", env);
+
+    // DB connection (adjust per app if needed)
     app.WithEnvironment(
         "ConnectionStrings__DefaultConnection",
         $"Server=localhost,1433;Database=HoneyHub.Users.Database;User ID=sa;Password={saPassword};Encrypt=True;TrustServerCertificate=True;MultipleActiveResultSets=True");
 
-    // Serilog base config (console as 0)
+    // Serilog base (console 0)
     app.WithEnvironment("Serilog__WriteTo__0__Name", "Console")
        .WithEnvironment("Serilog__WriteTo__0__Args__formatter", "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact");
 
-    // When Local, add Seq sink
+    // Seq sink in local
     if (seq is not null)
     {
         app.WithEnvironment("Serilog__WriteTo__1__Name", "Seq")
            .WithEnvironment("Serilog__WriteTo__1__Args__serverUrl", seq.GetEndpoint("ui"));
     }
 
+    // ---------- OpenTelemetry ----------
+    app.WithEnvironment("OTEL_SERVICE_NAME", app.Resource.Name) // e.g., "usersapi", "honeyhub-admin"
+       .WithEnvironment("OTEL_RESOURCE_ATTRIBUTES", $"deployment.environment={env}")
+       .WithEnvironment("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+       .WithEnvironment("OTEL_TRACES_SAMPLER_ARG", env == "Local" ? "1.0" : "0.2")
+       .WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_ENABLEOTLPLOGS", "true");
+
+    // Point services at collector in local
+    if (otel is not null)
+    {
+        app.WithEnvironment("OTEL_EXPORTER_OTLP_ENDPOINT", otel.GetEndpoint("otlpgrpc"));
+        // If you want HTTP instead of gRPC:
+        // app.WithEnvironment("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf");
+    }
+
     return app;
 }
 
+// ---------- Register your projects ----------
 WireApp(builder.AddProject<Projects.HoneyHub_Users_Api>("usersapi"));
 WireApp(builder.AddProject<Projects.HoneyHub_Admin>("honeyhub-admin"));
 
+// ---------- Run ----------
 builder.Build().Run();

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/dashboards/honeyhub-overview.json
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/dashboards/honeyhub-overview.json
@@ -1,0 +1,156 @@
+﻿{
+  "uid": "honeyhub-overview",
+  "title": "HoneyHub — Service Overview",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "tags": [ "honeyhub", "otel", "dotnet" ],
+  "refresh": "10s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "includeAll": true,
+        "multi": true,
+        "refresh": 2,
+        "query": "label_values(process_runtime_dotnet_gc_collections_count, service_name)"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Requests / sec",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_duration_count{service_name=~\"$service\"}[$__rate_interval])) or sum(rate(aspnetcore_requests_per_second{service_name=~\"$service\"}[$__rate_interval]))",
+          "legendFormat": "rps"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Error Rate (5xx / sec)",
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_duration_count{service_name=~\"$service\", http_response_status_code=~\"5..\"}[$__rate_interval]))",
+          "legendFormat": "errors/s"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Latency p95 (ms)",
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "1e3 * histogram_quantile(0.95, sum by (le) (rate(http_server_duration_bucket{service_name=~\"$service\"}[$__rate_interval])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": ".NET GC Heap (MB)",
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "mebibytes" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(process_runtime_dotnet_gc_heap_size{service_name=~\"$service\"}) / 1024 / 1024",
+          "legendFormat": "{{service_name}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": ".NET GC Collections / sec",
+      "gridPos": {
+        "x": 12,
+        "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(process_runtime_dotnet_gc_collections_count{service_name=~\"$service\"}[$__rate_interval]))",
+          "legendFormat": "{{service_name}}"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "Recent logs (Loki)",
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 24,
+        "h": 10
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "options": {
+        "showLabels": true,
+        "wrapLogMessage": true
+      },
+      "targets": [
+        { "expr": "{service=~\"$service\"}" }
+      ]
+    }
+  ]
+}

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/grafana-dashboards.yaml
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/grafana-dashboards.yaml
@@ -1,0 +1,11 @@
+﻿apiVersion: 1
+providers:
+  - name: 'HoneyHub'
+    orgId: 1
+    folder: 'HoneyHub'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/grafana-datasource.yaml
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/grafana-datasource.yaml
@@ -1,0 +1,22 @@
+﻿apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/loki.yaml
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/loki.yaml
@@ -1,0 +1,25 @@
+﻿auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/otel-collector.yaml
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/otel-collector.yaml
@@ -1,0 +1,50 @@
+﻿receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch: {}
+
+exporters:
+  # keep debug for quick "is it flowing?" checks in container logs
+  debug:
+    verbosity: normal
+
+  # Prometheus endpoint for your existing Prometheus scraper
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+    send_timestamps: true
+    resource_to_telemetry_conversion:
+      enabled: true
+
+  # Traces -> Tempo (OTLP over HTTP)
+  otlphttp/tempo:
+    endpoint: http://tempo:4318
+
+  # Logs -> Loki (needs *contrib* collector image)
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
+    labels:
+      resource:
+        service.name: service
+        deployment.environment: env
+      attributes:
+        log_severity: severity
+    # optional: format: json
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/tempo, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [loki, debug]

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/prometheus.yaml
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/prometheus.yaml
@@ -1,0 +1,9 @@
+﻿global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  # Scrape the OTel Collector's Prometheus exporter endpoint
+  - job_name: "otel-collector"
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/tempo.yaml
+++ b/HoneyHub.Platform/Shared/HoneyHub.Platform.AppHost/observability/tempo.yaml
@@ -1,0 +1,28 @@
+﻿server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http: {}
+        grpc: {}
+
+ingester:
+  # small, dev-friendly defaults
+  trace_idle_period: 10s       # how long to wait before cutting a block
+  max_block_bytes: 10485760    # 10 MB
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 24h       # keep local blocks for a day in dev
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces   # must match the container volume path
+    wal:
+      path: /var/tempo/wal


### PR DESCRIPTION
Added OpenTelemetry packages to enable tracing, metrics, and logging in the `HoneyHub.Users.Api` project. Updated `Program.cs` to configure OpenTelemetry services and logging integration. Enhanced local development setup with containers for OpenTelemetry Collector, Prometheus, Grafana, Tempo, and Loki. Created new YAML and JSON configuration files for Grafana dashboards and data sources.

BREAKING CHANGE: Modified project SDK declaration in `HoneyHub.Platform.AppHost.csproj`.